### PR TITLE
More simple api to create `Adt.Context`.

### DIFF
--- a/modules/main/simple-adt/core/shared/src/main/scala/net/scalax/simple/adt/AdtAliasAbs.scala
+++ b/modules/main/simple-adt/core/shared/src/main/scala/net/scalax/simple/adt/AdtAliasAbs.scala
@@ -3,10 +3,16 @@ package impl
 
 object Adt extends TypeAdtAlias with TypeAdtRuntimeApply {
 
-  class Adapter[Target, Poly](val value: Target)
+  case class Adapter[Target, Poly](value: Target)
 
   trait Context[In, Out, Poly] extends Any {
     def input(t: In): Out
+  }
+
+  object Context {
+    def apply[In, Out, Poly](func: In => Out): Context[In, Out, Poly] = new Context[In, Out, Poly] {
+      def input(t: In): Out = func(t)
+    }
   }
 
   sealed trait Status

--- a/modules/main/simple-adt/core/shared/src/test/scala-no-js/net/scalax/simple/adt/test/Test Cases copy from documention in README.md.scala
+++ b/modules/main/simple-adt/core/shared/src/test/scala-no-js/net/scalax/simple/adt/test/Test Cases copy from documention in README.md.scala
@@ -40,9 +40,7 @@ object `Test Cases copy from documention in README.md` {
     object JsonAdtPoly {
       implicit def jsonAdtPolyImplicit[In: Encoder]: Adt.Context[In, Json, JsonAdtPoly.type] = {
         val encoder = Encoder[In]
-        new Adt.Context[In, Json, JsonAdtPoly.type] {
-          override def input(t: In): Json = encoder(t)
-        }
+        Adt.Context(t => encoder(t))
       }
     }
 
@@ -54,6 +52,8 @@ object `Test Cases copy from documention in README.md` {
     assert(inputAdtData(None) == "Null Tag".asJson)
     assert(inputAdtData(Some(2)) == 3.asJson)
     assert(inputAdtData("My Name") == "My Name".asJson)
+    // Bypass compiler judgment
+    assert(inputAdtData(Adt.Adapter[Json, JsonAdtPoly.type]("Test Adapter".asJson)) == "Test Adapter".asJson)
   }
 
   def `Usage of @djx314 Point 3`[T](body: => T): T = body


### PR DESCRIPTION
Replace
``` scala
new Adt.Context {
  // code
}
```
to
``` scala
Adt.Context(t => dosomething.)
```